### PR TITLE
API-5099 - Supports any ISO 8601 date format for a file transfer LastUpdated & ReviewedDate fields.

### DIFF
--- a/app/uk/gov/hmrc/integrationcatalogue/models/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/integrationcatalogue/models/JsonFormatters.scala
@@ -19,12 +19,7 @@ package uk.gov.hmrc.integrationcatalogue.models
 import play.api.libs.json._
 import uk.gov.hmrc.integrationcatalogue.models.common._
 
-object JsonFormatters {
-
-  val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-  implicit val JodaDateReads: Reads[org.joda.time.DateTime] = JodaReads.jodaDateReads(dateFormat)
-  implicit val JodaDateWrites: Writes[org.joda.time.DateTime] = JodaWrites.jodaDateWrites(dateFormat)
-  implicit val JodaDateTimeFormat: Format[org.joda.time.DateTime] = Format(JodaDateReads, JodaDateWrites)
+object JsonFormatters extends JodaReads with JodaWrites {
 
   implicit val formatContactInformation: Format[ContactInformation] = Json.format[ContactInformation]
 

--- a/app/uk/gov/hmrc/integrationcatalogueadmin/controllers/PublishController.scala
+++ b/app/uk/gov/hmrc/integrationcatalogueadmin/controllers/PublishController.scala
@@ -69,7 +69,7 @@ class PublishController @Inject() (
       case Success(validBody) => if (validatePlatformTypesMatch(validBody, platformHeader)) publishService.publishFileTransfer(validBody).map(handlePublishResult)
         else Future.successful(BadRequest(Json.toJson(ErrorResponse(List(ErrorResponseMessage("Invalid request body - platform type mismatch"))))))
       case Failure(exception) => {
-        logger.info("Invalid request body, must be a valid publish request", exception)
+        logger.error("Invalid request body, must be a valid publish request", exception)
           Future.successful(BadRequest(Json.toJson(ErrorResponse(List(
             ErrorResponseMessage("Invalid request body"),
             ErrorResponseMessage(exception.getMessage)

--- a/app/uk/gov/hmrc/integrationcatalogueadmin/utils/JsonUtils.scala
+++ b/app/uk/gov/hmrc/integrationcatalogueadmin/utils/JsonUtils.scala
@@ -17,22 +17,17 @@
 package uk.gov.hmrc.integrationcatalogueadmin.utils
 
 import play.api.libs.json.{JsValue, Json, Reads}
+import play.api.Logging
+import scala.util.Try
 
-import scala.util.{Failure, Success, Try}
-
-trait JsonUtils {
-
-  def validateAndExtractJsonString[T](body: String)(implicit  reads: Reads[T]) = {
+trait JsonUtils extends Logging {
+  def validateAndExtractJsonString[T](body: String)(implicit  reads: Reads[T]) : Try[T] = {
     validateJsonAndExtract[T](body, body => Json.parse(body))
   }
 
-  private def validateJsonAndExtract[T](body: String, f: String => JsValue)(implicit reads: Reads[T]) = {
+  private def validateJsonAndExtract[T](body: String, f: String => JsValue)(implicit reads: Reads[T]) : Try[T] = {
     Try[T] {
       f(body).as[T]
-    } match {
-      case Success(result) => Some(result)
-      case Failure(_) => None
     }
   }
-
 }

--- a/it/controllers/PublishControllerISpec.scala
+++ b/it/controllers/PublishControllerISpec.scala
@@ -368,8 +368,8 @@ class PublishControllerISpec extends ServerBaseISpec with BeforeAndAfterEach wit
 
         val response: Future[Result] = route(app, invalidFileTransferJsonPublishRequest).get
         status(response) mustBe BAD_REQUEST
-        contentAsString(response) mustBe """{"errors":[{"message":"Invalid request body"}]}"""
-
+        contentAsString(response) must(include("""{"message":"Invalid request body"}"""))
+        contentAsString(response) must(include("""JsResultException(errors:List((,List(JsonValidationError(List(error.expected.jsobject),WrappedArray())))))"""))
       }
 
       "respond with 401 and error message Authorization header is missing" in new Setup{
@@ -439,8 +439,8 @@ class PublishControllerISpec extends ServerBaseISpec with BeforeAndAfterEach wit
 
         val response: Future[Result] = route(app, invalidYamlFileTransferPublishRequest).get
         status(response) mustBe BAD_REQUEST
-        contentAsString(response) mustBe """{"errors":[{"message":"Error parsing yaml"}]}"""
-
+        contentAsString(response) must(include("""{"message":"Error parsing yaml"}"""))
+        contentAsString(response) must(include("""JsResultException(errors:List((,List(JsonValidationError(List(error.expected.jsobject),WrappedArray())))))"""))
       }
 
       "respond with 401 and error message Authorization header is missing" in new Setup{

--- a/it/controllers/PublishControllerISpec.scala
+++ b/it/controllers/PublishControllerISpec.scala
@@ -141,6 +141,38 @@ class PublishControllerISpec extends ServerBaseISpec with BeforeAndAfterEach wit
         Headers(basePublishHeaders: _*),
         Json.toJson(fileTransferPublishRequestObj))
 
+    val validFileTransferJsonPublishRequestWithAlternativeDate: FakeRequest[JsValue] = {
+      val json = """
+        {
+          "fileTransferSpecificationVersion":"1.0",
+          "publisherReference":"validFileTransferJsonPublishRequestWithAlternativeDate",
+          "title":"XXX-YYY-ZZZMonthly-pull",
+          "description":"A file transfer",
+          "platformType":"CORE_IF",
+          "lastUpdated":"2020-11-04",
+          "reviewedDate":"2020-11-24",
+          "contact":{
+              "name":"Core IF Team",
+              "emailAddress":"example@gmail.com"
+          },
+          "sourceSystem":[
+              "XXX"
+          ],
+          "targetSystem":[
+              "YYY"
+          ],
+          "transports":[
+              "UTM"
+          ],
+          "fileTransferPattern":"Corporate to corporate"
+        }
+      """
+      FakeRequest(Helpers.PUT,
+        "/integration-catalogue-admin-api/services/filetransfers/publish",
+        Headers(basePublishHeaders: _*),
+        Json.parse(json))
+    }
+
     val validFileTransferYamlPublishRequest: FakeRequest[JsValue] =
       FakeRequest(Helpers.PUT,
         "/integration-catalogue-admin-api/services/filetransfers/publish/yaml",
@@ -339,6 +371,18 @@ class PublishControllerISpec extends ServerBaseISpec with BeforeAndAfterEach wit
         primePutWithBody("/integration-catalogue/filetransfer/publish", OK, Json.toJson(backendResponse).toString)
 
         val response: Future[Result] = route(app, validFileTransferJsonPublishRequest.withHeaders(coreIfPlatformTypeHeader ++ masterKeyHeader : _*)).get
+        status(response) mustBe CREATED
+        // check body
+      }
+
+      "respond with 201 when valid request with alternative date format (yyyy-mm-dd)" in new Setup{
+        val backendResponse: PublishResult = createBackendPublishResponse(isSuccess = true, isUpdate = false)
+        primePutWithBody("/integration-catalogue/filetransfer/publish", OK, Json.toJson(backendResponse).toString)
+
+        val response: Future[Result] = route(app, validFileTransferJsonPublishRequestWithAlternativeDate
+          .withHeaders(coreIfPlatformTypeHeader ++ masterKeyHeader : _*))
+          .get
+
         status(response) mustBe CREATED
         // check body
       }


### PR DESCRIPTION
- Now supports any ISO 8601 date format for a file transfer LastUpdated & ReviewedDate fields.
- Improved publish API error response, returns any JSON parse errors in the 400 response.